### PR TITLE
Automate build info into gradle.properties

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -49,8 +49,14 @@ tasks.withType<Test> {
 }
 
 tasks {
+    processResources {
+        filesMatching("extension.json") {
+            expand(project.properties)
+        }
+    }
+
     named<com.github.jengelman.gradle.plugins.shadow.tasks.ShadowJar>("shadowJar") {
-        archiveBaseName.set("example")
+        archiveBaseName.set(project.name)
         mergeServiceFiles()
         minimize()
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,1 +1,6 @@
+# suppress inspection "UnusedProperty" for whole file - used in extension.json
 kotlin.code.style=official
+name=ExampleExtension
+mainClass=ExampleExtension
+group=world.cepi.example
+version=1.0.0-EXAMPLE

--- a/src/main/resources/extension.json
+++ b/src/main/resources/extension.json
@@ -1,5 +1,5 @@
 {
-  "entrypoint": "world.cepi.example.ExampleExtension",
-  "name": "ExampleExtension",
-  "version": "1.0.0-EXAMPLE"
+  "entrypoint": "${project.group}.${project.mainClass}",
+  "name": "${project.name}",
+  "version": "${project.version}"
 }


### PR DESCRIPTION
This PR adds some properties into `gradle.properties` that are then used to create the `extension.json` file in the `processResources` step and name the final jar.